### PR TITLE
Fix save food crash

### DIFF
--- a/Omega/src/LyzzardBucket.cpp
+++ b/Omega/src/LyzzardBucket.cpp
@@ -3,12 +3,35 @@
 
 LyzzardBucket::LyzzardBucket(void)
 {
-	id = FOODID + 0;
-	objstr = "red and white striped bucket";
-	truename = "Lyzzard Bucket";
-	cursestr = "Lyzzard Bucket";
+    id = FOODID + 0;
+    objstr = "red and white striped bucket";
+    truename = "Lyzzard Bucket";
+    cursestr = "Lyzzard Bucket";
 }
 
 LyzzardBucket::~LyzzardBucket(void)
 {
+}
+
+LyzzardBucket::LyzzardBucket(Object *o) : LyzzardBucket() {
+    weight = o->weight;
+    plus = o->plus;
+    charge = o->charge;
+    dmg = o->dmg;
+    hit = o->hit;
+    aux = o->aux;
+    number = o->number;
+    fragility = o->fragility;
+    basevalue = o->basevalue;
+    known = o->known;
+    used = o->used;
+    blessing = o->blessing;
+    type = o->type;
+    uniqueness = o->uniqueness;
+    usef = o->usef;
+    level = o->level;
+    objchar = o->objchar;
+    if(o->objstr != NULL) objstr = o->objstr;
+    if(o->truename != NULL) truename = o->truename;
+    if(o->cursestr != NULL) cursestr = o->cursestr;
 }

--- a/Omega/src/LyzzardBucket.h
+++ b/Omega/src/LyzzardBucket.h
@@ -5,5 +5,8 @@ class LyzzardBucket : public Food
 {
 public:
 	LyzzardBucket();
+
+	LyzzardBucket(Object *pObject);
+
 	~LyzzardBucket();
 };

--- a/Omega/src/save.cpp
+++ b/Omega/src/save.cpp
@@ -701,6 +701,7 @@ Object* restore_item(FILE *fd, int version)
         if(obj->id == FOODID+0) {
             Object *old = obj;
             obj = new LyzzardBucket(obj);
+            free(old);
         }
     }
     return obj;

--- a/Omega/src/save.cpp
+++ b/Omega/src/save.cpp
@@ -2,6 +2,7 @@
 /* save.c */
 
 #include "glob.h"
+#include "LyzzardBucket.h"
 
 /*Various functions for doing game saves and restores */
 /*The game remembers various player information, the city level,
@@ -696,6 +697,10 @@ Object* restore_item(FILE *fd, int version)
             }
             else
                 obj->cursestr = Objects[obj->id].cursestr;
+        }
+        if(obj->id == FOODID+0) {
+            Object *old = obj;
+            obj = new LyzzardBucket(obj);
         }
     }
     return obj;

--- a/Omega/src/util.cpp
+++ b/Omega/src/util.cpp
@@ -909,8 +909,12 @@ int ok_to_free(plv level)
 void free_obj( Object* obj, int flag )
 {
     if ( flag && (obj->id == CORPSEID) && (obj->level & ALLOC) )
-        free( obj->objstr );
-    free( (char *) obj );
+        free( (char *)obj->objstr );
+    if(obj->id == FOODID+0) {
+        delete obj;
+    } else {
+        free( (char *) obj );
+    }
 }
 
 Object* copy_obj ( Object* obj )

--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR := obj
 CPP := g++
 LD := g++
 
-CFLAGS :=
+CFLAGS := -std=c++11
 LDFLAGS := -lcurses
 
 DATA_DIR := ../../data


### PR DESCRIPTION
Because of the way the LyzzardBuckets were converted into an object, the restore process did not reconstruct them correctly, so the `o->eat()` call would segfault.  This meant that any Lyzzard food you had on you when you saved would crash if you ate it after restoring a game.