### PR TITLE
Fixed crash bug when cancelling apport

### DIFF
--- a/Omega/src/effect3.cpp
+++ b/Omega/src/effect3.cpp
@@ -542,7 +542,10 @@ void apport(int blessing)
     if (blessing > -1) {
         mprint("Apport from:");
         setspot(&x,&y);
-        if (Level->site[x][y].things != NULL) {
+        if(x < 0 || y < 0) {
+          mprint("Cancelled.");
+        }
+        else if (Level->site[x][y].things != NULL) {
             pickup_at(x,y);
             plotspot(x, y, true);
         }


### PR DESCRIPTION
If a player cancels apport with ESC, `setspot` will set `x` and `y` each to -1, which causes a crash when those are used to index `Level->site`. This commit simply checks their values and outputs "Canceled." if either of them is less than 0.