### PR TITLE
Removed escape delay for ncurses builds

### DIFF
--- a/Omega/src/scr.cpp
+++ b/Omega/src/scr.cpp
@@ -587,6 +587,10 @@ void initgraf(void)
     start_color();
     clrgen_init();
 
+#ifndef PDCURSES
+    set_escdelay(0);
+#endif
+
     if (LINES < 24 || COLS < 80) {
         printf("Minimum Screen Size: 24 Lines by 80 Columns.");
         exit(0);


### PR DESCRIPTION
For whatever reason, the default behavior in ncurses is for there to be a delay when the escape key is hit. I think it has something to do with differentiating between the escape key and escape-codes on legacy terminal hardware where not all data is always received immediately. I don't think this is necessary on modern hardware. I have had this delay disabled in my fork of Omega for awhile now with no ill effect. It's wrapped in an `#ifndef PDCURSES`, because PDCurses does not have this function and already defaults to zero delay.