### PR TITLE
Fixed crash bug when cancelling fire on wilderness map

### DIFF
--- a/Omega/src/command3.cpp
+++ b/Omega/src/command3.cpp
@@ -268,7 +268,11 @@ void fire(void)
         x1 = x2 = Player.x;
         y1 = y2 = Player.y;
         setspot(&x2,&y2);
-        if ((x2 == Player.x) && (y2 == Player.y))
+        if (x2 == ABORT || y2 == ABORT) {
+            State.setSkipMonsters();
+            mprint("Cancelled.");
+        }
+        else if ((x2 == Player.x) && (y2 == Player.y))
             mprint("You practice juggling for a moment or two.");
         else {
             do_object_los(obj->objchar,&x1,&y1,x2,y2);


### PR DESCRIPTION
When cancelling the `fire` command with ESC, setspot sets x2 and y2 to ABORT (-1), which was not being checked for and results in the weapon being thrown to the northwest. Under normal circumstances, this is only a mild annoyance, but on unbordered maps such as in the wilderness, this will cause the weapon to fly out of bounds, resulting in a crash. This commit simply adds an extra check and outputs "Cancelled." instead of firing the weapon when applicable.