### PR TITLE
Fixed handling of backspace for ncurses builds

### DIFF
--- a/Omega/src/aux3.cpp
+++ b/Omega/src/aux3.cpp
@@ -878,7 +878,8 @@ void showknownsites(int first, int last)
 int parsecitysite()
 {
     int first, last, pos;
-    char byte, prefix[80];
+    char prefix[80];
+    int byte;
     int found = 0;
     int f, l;
 
@@ -888,7 +889,7 @@ int parsecitysite()
     print2("");
     do {
         byte = mgetc();
-        if (byte == BACKSPACE || byte == DELETE_CHAR) {
+        if (byte == BACKSPACE || byte == DELETE_CHAR || byte == KEY_BACKSPACE) {
             if (pos > 0) {
                 prefix[--pos] = '\0';
                 byte = prefix[pos - 1];

--- a/Omega/src/bank.cpp
+++ b/Omega/src/bank.cpp
@@ -181,7 +181,7 @@ static int input_password (WINDOW *w, int line, int col, char *buf, int allow_es
             *buf = ESCAPE;
             return 1;
         }
-        else if (KEY_LEFT == key || DELETE_CHAR == key || BACKSPACE == key)
+        else if (KEY_LEFT == key || DELETE_CHAR == key || BACKSPACE == key || KEY_BACKSPACE == key)
         {
             if (pwlen > 0)
             {
@@ -218,7 +218,7 @@ static long input_amount (WINDOW *w, int line, int col)
 
         if ('\n' == key) return sign * amount;
 
-        if (KEY_LEFT == key || DELETE_CHAR == key || BACKSPACE == key)
+        if (KEY_LEFT == key || DELETE_CHAR == key || BACKSPACE == key || KEY_BACKSPACE == key)
         {
             if (amountlen > 0)
             {

--- a/Omega/src/command3.cpp
+++ b/Omega/src/command3.cpp
@@ -711,6 +711,7 @@ void tacoptions(void)
             break;
         case BACKSPACE:
         case DELETE_CHAR:
+        case KEY_BACKSPACE:
             place = 0;
             actionsleft=maneuvers();
             draw_again = 1;

--- a/Omega/src/scr.cpp
+++ b/Omega/src/scr.cpp
@@ -1408,13 +1408,14 @@ void draw_explosion(Symbol pyx, int x, int y)
 
 char *msgscanstring(void)
 {
-    static char instring[80],byte='x';
+    static char instring[80];
+    static int byte='x';
     int i=0;
 
     instring[0]=0;
     byte = mgetc();
     while (byte != '\n') {
-        if ((byte == 8) || (byte == 127)) { /* ^h or delete */
+        if (byte == DELETE_CHAR || byte == BACKSPACE || byte == KEY_BACKSPACE) { /* ^h or delete */
             if (i>0) {
                 i--;
                 dobackspace();
@@ -1538,7 +1539,7 @@ static long input_number (WINDOW * w)
         {
             return ABORT;
         }
-        else if (BACKSPACE == ch || DELETE_CHAR == ch)
+        else if (BACKSPACE == ch || DELETE_CHAR == ch || KEY_BACKSPACE == ch)
         {
             if (numlen > 0)
             {
@@ -1570,13 +1571,13 @@ long parsenum (const char *message)
     int place = -1;
     int i,x,y,mult=1;
     long num=0;
-    char byte=' ';
+    int byte=' ';
     int entering_digits = true;
 
     cinema_display(message, "enter a number or ESC: ", NULL);
     while (entering_digits) {
         byte = wgetch(Cinema);
-        if ((byte == BACKSPACE) || (byte == DELETE_CHAR)) {
+        if (byte == BACKSPACE || byte == DELETE_CHAR || byte == KEY_BACKSPACE) {
             if (place > -1) {
                 number[place] = 0;
                 place--;

--- a/Omega/src/spell.cpp
+++ b/Omega/src/spell.cpp
@@ -875,7 +875,8 @@ void showknownspells(int first, int last)
 int spellparse(void)
 {
     int first, last, pos;
-    char byte, prefix[80];
+    char prefix[80];
+    int byte;
     int found = 0;
     int f, l;
 
@@ -891,7 +892,7 @@ int spellparse(void)
     print2("");
     do {
         byte = mgetc();
-        if (byte == BACKSPACE || byte == DELETE_CHAR) {
+        if (byte == BACKSPACE || byte == DELETE_CHAR || byte == KEY_BACKSPACE) {
             if (pos > 0) {
                 prefix[--pos] = '\0';
                 byte = prefix[pos - 1];


### PR DESCRIPTION
In ncurses, backspace key is returned from wgetch as KEY_BACKSPACE. This is one of the situations where PDCurses and ncurses have different behavior. PDCurses has KEY_BACKSPACE defined, but for whatever reason does not make use of it. It is simple enough to add a check for KEY_BACKSPACE in addition to the other values it checks. Without this, ncurses builds of the program do not handle the backspace character properly.